### PR TITLE
TINY-6272: Fixed incorrect FakeTiny types

### DIFF
--- a/src/main/ts/alien/Types.ts
+++ b/src/main/ts/alien/Types.ts
@@ -1,5 +1,4 @@
 export interface FakeTiny {
   majorVersion: string;
   minorVersion: string;
-  plugins: Record<string, any>;
 }

--- a/src/test/ts/browser/TinyVerTest.ts
+++ b/src/test/ts/browser/TinyVerTest.ts
@@ -12,7 +12,7 @@ UnitTest.test('TinyVerTest', () => {
   const assertgetVersion = (expected: VersionBlock, tiny: FakeTiny) => {
     assert.eq(expected, TinyVer.getVersion(tiny));
   };
-  const fakeTiny = (majorVersion: string, minorVersion: string): FakeTiny => ({ majorVersion, minorVersion, plugins: {} });
+  const fakeTiny = (majorVersion: string, minorVersion: string): FakeTiny => ({ majorVersion, minorVersion });
   const v = (major: number, minor: number, patch: number): VersionBlock => ({ major, minor, patch });
 
   assertgetVersion(v(1, 2, 3), fakeTiny('1', '2.3'));


### PR DESCRIPTION
`plugins` isn't on the tinymce global, it's on the editor instance so this just removes the invalid property that wasn't being used anyways.