### PR TITLE
TINY-7404: Added new VersionHooks module to support BDD style tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
+- Added new `VersionHooks` module to support BDD style tests #TINY-7404

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinymce/miniature",
-  "version": "3.1.2-rc",
+  "version": "3.2.0-rc",
   "description": "This library checks versions of TinyMCE.",
   "scripts": {
     "prepublishOnly": "tsc",
     "lint": "eslint 'src/**/*.ts'",
     "build": "tsc",
-    "test": "yarn lint && bedrock-auto -b phantomjs -d src/test/ts/browser",
+    "test": "yarn lint && bedrock-auto -b chrome-headless -d src/test/ts/browser",
     "test-manual": "bedrock -d src/test/ts/browser"
   },
   "repository": {

--- a/src/main/ts/api/Main.ts
+++ b/src/main/ts/api/Main.ts
@@ -1,7 +1,9 @@
 import * as TinyVer from './TinyVer';
+import * as VersionHooks from './VersionHooks';
 import * as VersionLoader from './VersionLoader';
 
 export {
   TinyVer,
+  VersionHooks,
   VersionLoader
 };

--- a/src/main/ts/api/VersionHooks.ts
+++ b/src/main/ts/api/VersionHooks.ts
@@ -1,0 +1,115 @@
+import { after, afterEach, before } from '@ephox/bedrock-client';
+import { Arr, Obj, Optional } from '@ephox/katamari';
+import { TinyHooks } from '@ephox/mcagar';
+import { SugarElement } from '@ephox/sugar';
+import { load } from '../loader/Loader';
+import { PluginDetails, readPlugins, registerPlugins } from '../loader/Plugins';
+
+export interface Hook<T> {
+  readonly editor: () => T;
+}
+
+export interface ShadowRootHook<T> extends Hook<T> {
+  readonly shadowRoot: () => SugarElement<ShadowRoot>;
+}
+
+const setupVersion = <T, H extends Hook<T>>(
+  version: string,
+  setupModules: Record<string, Array<() => void>>,
+  setupHook: (setupPluginModules: Array<() => void>) => H
+): H => {
+  let hasFailure = false;
+  let plugins: Optional<PluginDetails[]> = Optional.none();
+  const pluginNames = Obj.keys(setupModules);
+  const modules = Arr.flatten(Obj.values(setupModules));
+
+  before(function (done) {
+    // Increase the default timeout to ensure we have time to load
+    this.timeout(4000);
+    // Store the original plugins
+    plugins = Optional.some(readPlugins(pluginNames));
+    // load the new version and restore the loaded plugins
+    load(version, () => {
+      plugins.each(registerPlugins);
+      done();
+    }, done);
+  });
+
+  const hook = setupHook(modules);
+
+  afterEach(function () {
+    if (this.currentTest?.isFailed() === true) {
+      hasFailure = true;
+    }
+  });
+
+  after(function (done) {
+    // Increase the default timeout to ensure we have time to load
+    this.timeout(4000);
+    if (hasFailure) {
+      done();
+    } else {
+      // load the latest version back into scope
+      load('latest', () => {
+        // Restore the original plugins
+        plugins.each(registerPlugins);
+        plugins = Optional.none();
+        done();
+      }, done);
+    }
+  });
+
+  return hook;
+};
+
+const bddSetupVersion = <T = any>(
+  version: string,
+  settings: Record<string, any>,
+  setupModules: Record<string, Array<() => void>> = {},
+  focusOnInit: boolean = false
+): Hook<T> => {
+  return setupVersion(version, setupModules, (modules) => {
+    return TinyHooks.bddSetup<any>(settings, modules, focusOnInit);
+  });
+};
+
+const bddSetupVersionLight = <T = any>(
+  version: string,
+  settings: Record<string, any>,
+  setupModules: Record<string, Array<() => void>> = {},
+  focusOnInit: boolean = false
+): Hook<T> => {
+  return setupVersion(version, setupModules, (modules) => {
+    return TinyHooks.bddSetupLight<any>(settings, modules, focusOnInit);
+  });
+};
+
+const bddSetupVersionFromElement = <T = any>(
+  version: string,
+  settings: Record<string, any>,
+  setupElement: () => TinyHooks.SetupElement,
+  setupModules: Record<string, Array<() => void>> = {},
+  focusOnInit: boolean = false
+): Hook<T> => {
+  return setupVersion(version, setupModules, (modules) => {
+    return TinyHooks.bddSetupFromElement<any>(settings, setupElement, modules, focusOnInit);
+  });
+};
+
+const bddSetupVersionInShadowRoot = <T = any>(
+  version: string,
+  settings: Record<string, any>,
+  setupModules: Record<string, Array<() => void>> = {},
+  focusOnInit: boolean = false
+): ShadowRootHook<T> => {
+  return setupVersion(version, setupModules, (modules) => {
+    return TinyHooks.bddSetupInShadowRoot<any>(settings, modules, focusOnInit);
+  });
+};
+
+export {
+  bddSetupVersion,
+  bddSetupVersionLight,
+  bddSetupVersionFromElement,
+  bddSetupVersionInShadowRoot
+};


### PR DESCRIPTION
Related Ticket: TINY-7404

Description of Changes:
* Added new `VersionHooks` module to support BDD style tests

Note: The `any` is deliberate for the default types, as we can't be sure of the Editor type and may not be able to provide an accurate type when dealing across multiple versions.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
* [x] Review comments resolved
