### PR TITLE
TINY-8756: Update GitHub CODEOWNERS and PR template files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tinymce/editor-platform-team
+* @tinymce/tinymce-reviewers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,3 @@ Before merging:
 * [ ] Ensure internal dependencies are on appropriate versions
   * For stable releases, all dependencies must be stable
   * For release candidates, all dependencies must be release candidates or stable
-* [ ] Review comments resolved


### PR DESCRIPTION
Related Ticket: TINY-8756

Description of Changes:
* Update the codeowners to use the new reviewers group
* Remove the comments resolved checkbox from the PR template as we'll use the branch protection instead

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
* [x] Review comments resolved
